### PR TITLE
Show full dates instead of timestamps

### DIFF
--- a/files/Callback.php
+++ b/files/Callback.php
@@ -45,7 +45,7 @@
   //> Send email
   $htmlTemplate = str_replace(
     ["{{id}}", "{{domain}}", "{{url}}", "{{ip}}", "{{referer}}", "{{user-agent}}", "{{cookies}}", "{{dom}}", "{{screenshot}}", "{{origin}}", "{{time}}"],
-    [$id, $domain, htmlspecialchars($jsonDecoded["uri"]), $userIP, htmlspecialchars($jsonDecoded["referrer"]), htmlspecialchars($jsonDecoded["user-agent"]), htmlspecialchars($jsonDecoded["cookies"]), htmlspecialchars(substr($jsonDecoded["dom"], 0, $domPart)) . $domExtra, $imageUrl, htmlspecialchars($jsonDecoded["origin"]), time()],
+    [$id, $domain, htmlspecialchars($jsonDecoded["uri"]), $userIP, htmlspecialchars($jsonDecoded["referrer"]), htmlspecialchars($jsonDecoded["user-agent"]), htmlspecialchars($jsonDecoded["cookies"]), htmlspecialchars(substr($jsonDecoded["dom"], 0, $domPart)) . $domExtra, $imageUrl, htmlspecialchars($jsonDecoded["origin"]), date('Y/m/d h:i:s A')],
     file_get_contents("manage/src/templates/site/mail.htm")
   );
 

--- a/files/manage/src/Component.php
+++ b/files/manage/src/Component.php
@@ -47,7 +47,7 @@
     public function report($i) {
       if(isset($_GET["id"])) {
         $report = $this->database->newQueryArray("SELECT * FROM reports WHERE id = :id LIMIT 1", array(":id" => $_GET["id"]));
-
+        $report["time"] = date('Y/m/d h:i:s A', $report["time"]);
         if(isset($report["id"])) {
           $html = file_get_contents(__DIR__ . "/templates/site/report-id.htm");
           preg_match_all("/{{(.*?)\[(.*?)\]}}/", $html, $matches);


### PR DESCRIPTION
Allow users to see the full date of a report instead of the unix timestamp.