### PR TITLE
Get real IP behind reverse proxy setup

### DIFF
--- a/src/Route.php
+++ b/src/Route.php
@@ -150,7 +150,7 @@ class Route
             $setting[$settings['setting']] = $settings['value'];
         }
 
-        $userIp = $json->ip ?? $_SERVER['HTTP_CF_CONNECTING_IP'] ?? $_SERVER['REMOTE_ADDR'];
+        $userIp = $json->ip ?? $_SERVER['HTTP_CF_CONNECTING_IP'] ?? $_SERVER['HTTP_X_REAL_IP'] ?? $_SERVER['REMOTE_ADDR'];
         $domain = htmlspecialchars($_SERVER['SERVER_NAME']);
         $json->origin = str_replace(['https://', 'http://'], '', $json->origin);
 


### PR DESCRIPTION
This small change allows users who are serving ezxss with a reverse proxy setup, like traefik, to get the real IPs in logs. Otherwise the logged IP would be a 172.x.x.x docker internal IP address.