### PR TITLE
Handled exception when settings table not created

### DIFF
--- a/src/Database.php
+++ b/src/Database.php
@@ -22,7 +22,7 @@ class Database
             if (debug === true) {
                 print $e->getMessage();
             }
-            error('Database connection failed. Check your config file.', true);
+            error('Database connection failed. Wait 30s or check your config file.', true);
         }
     }
 


### PR DESCRIPTION
Fixes #72

I had to do a janky str_contains because prepare() calls are hidden from the User class.

TL;DR: moved creating the settings table into a method, called it if the table doesn't exist.

Also updated the "Error connecting to DB" message because I just had quick hands. :~)

