### PR TITLE
Feature/generate native docker image

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 dbHost="ezxssdb"
-dbUser="ezxss"
-dbPassword="changeme"
-dbName="database"
+dbUser=ezxss
+dbPassword=changeme
+dbName=database

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 ezxssdb/
+.idea

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ version: '3'
 
 services:
   ezxssdb:
-    container_name: ${dbHost}
     image: mysql
     command: --default-authentication-plugin=mysql_native_password
     restart: always
@@ -14,7 +13,10 @@ services:
     volumes:
       - ./ezxssdb:/var/lib/mysql
   ezxss:
-    build: ./docker-php
+    build:
+      context: .
+      dockerfile: ./docker-php/Dockerfile
+      target: partial
     ports:
       - "80:80"
       - "443:443"

--- a/docker-php/Dockerfile
+++ b/docker-php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:apache
+FROM php:apache as partial
 
 # Load extra Apache modules
 RUN a2enmod rewrite headers
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y msmtp && rm -rf /var/lib/apt/lists/*
 # Installs php modules
 RUN docker-php-ext-install pdo_mysql
 # config msmtp https://owendavies.net/articles/setting-up-msmtp/
-COPY msmtprc /etc/msmtprc
+COPY ./docker-php/msmtprc /etc/msmtprc
 RUN chmod 600 /etc/msmtprc
 RUN touch /var/log/msmtp.log
 RUN chown www-data:www-data /etc/msmtprc
@@ -17,7 +17,17 @@ RUN chown www-data:www-data /var/log/msmtp.log
 RUN mkdir /var/www/html/assets/ && mkdir /var/www/html/assets/img
 RUN chmod 777 /var/www/html/assets/img
 
-
-
 # config php.ini
 RUN echo "sendmail_path = /usr/bin/msmtp -t" >> /usr/local/etc/php/conf.d/php-sendmail.ini
+
+FROM partial
+COPY ./.htaccess /var/www/html/
+COPY ./index.html /var/www/html/
+COPY ./init.php /var/www/html/
+COPY ./assets/ /var/www/html/assets/
+COPY ./templates/ /var/www/html/templates/
+COPY ./src/ /var/www/html/src/
+RUN find . -type f -exec sed -i 's/\r$//' {} \;
+
+ENTRYPOINT ["docker-php-entrypoint"]
+CMD ["apache2-foreground"]

--- a/docker-php/Dockerfile
+++ b/docker-php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:apache as partial
+FROM php:8-apache as partial
 
 # Load extra Apache modules
 RUN a2enmod rewrite headers

--- a/init.php
+++ b/init.php
@@ -11,7 +11,7 @@
 */
 
 define('version', '3.10');
-define('debug', true);
+define('debug', false);
 
 if (debug) {
     error_reporting(E_ALL);


### PR DESCRIPTION
Great work on this app. I've been using it with pleasure, thanks for the effort!

I have taken the courtesy to make some changes on the Docker integration for this application.
These changes allow to take full advantage of Docker by allowing the user to pull the image from Docker Hub instead of cloning this repository and building the images locally. This automatically adds support for Continuous Delivery/Deployment.

Why would someone want this?
- As a maintainer, you can configure Docker Hub to automatically rebuild and push the image when an upstream dependency (like PHP/Apache) has updated their images.
- As a maintainer, your changes to master can be automatically deployed.
- As a user, you can leverage tools like Watchtower to automatically pull updates.
- Furthermore, the Docker Hub image is immutable. There's no dependency on source files. You only need to link the database volume and the `.env` file.

A sample `docker-compose.yml`:
```yaml
version: '3'

services:
  ezxss.db:
    image: mysql:8  # note: this is also pinned to 8 to prevent possible breaking changes on future major upgrades.
    command: --default-authentication-plugin=mysql_native_password
    restart: unless-stopped
    environment:
      - MYSQL_RANDOM_ROOT_PASSWORD=yes
      - MYSQL_DATABASE=${dbName}
      - MYSQL_USER=${dbUser}
      - MYSQL_PASSWORD=${dbPassword}
    volumes:
      - ./ezxssdb:/var/lib/mysql

  ezxss.app:
    image: flightkick/ezxss:latest  # todo: update this reference to the offical Docker image if you choose to adopt this.
    ports:
      - "80:80"
      - "443:443"
    restart: unless-stopped
    volumes:
      - ./.env:/var/www/html/.env:ro
      - assets:/var/www/html/assets/
    depends_on:
      - ezxssdb

volumes:
  assets:
    driver: local
    driver_opts:
      o: bind
      type: none
      device: /absolute/path/to/host/directory/where/assets/should/be/mounted/
```

A sample `.env` file for this configuration:
```text
dbHost="ezxss.db"
dbUser=ezxss
dbPassword=changeme
dbName=ezxss
```

Example of Docker Hub configuration, offcourse this should refer to the master branch
![image](https://user-images.githubusercontent.com/8693699/110533336-2d10a680-811e-11eb-9d70-3e3c23ee6437.png)

Some other small changes I have included:
- Pin the PHP version to version 8 to prevent possible breaking changes on future major upgrades.
- Disable debug mode by default. This might have accidentally be committed here: https://github.com/ssl/ezXSS/commit/f7debdc3d6298a035a1f2eb8aea435224dc64170
- Removed some quotes from the `.env.example` file. Those were taken literally, so the db user would be `"ezxss"`
- Excluded IntelliJ IDEA files from the repository (.gitignore)
- Removed the `container_name` directive. Not necessary for container communication, those use the service name.