### PR TITLE
Feature: Allow configurable UID/GID in docker container

### DIFF
--- a/docker-php/Dockerfile
+++ b/docker-php/Dockerfile
@@ -21,13 +21,18 @@ RUN chmod 777 /var/www/html/assets/img
 RUN echo "sendmail_path = /usr/bin/msmtp -t" >> /usr/local/etc/php/conf.d/php-sendmail.ini
 
 FROM partial
+ENV PUID=2000
+ENV PGID=2000
+COPY ./docker-php/init.sh /init.sh
 COPY ./.htaccess /var/www/html/
 COPY ./index.html /var/www/html/
 COPY ./init.php /var/www/html/
 COPY ./assets/ /var/www/html/assets/
 COPY ./templates/ /var/www/html/templates/
 COPY ./src/ /var/www/html/src/
-RUN find . -type f -exec sed -i 's/\r$//' {} \;
+RUN find . -type f -exec sed -i 's/\r$//' {} \; && \
+    chmod +x /init.sh && \
+    sed -i -e 's/\r$//' /init.sh
 
-ENTRYPOINT ["docker-php-entrypoint"]
-CMD ["apache2-foreground"]
+ENTRYPOINT ["/bin/bash"]
+CMD ["/init.sh"]

--- a/docker-php/Dockerfile
+++ b/docker-php/Dockerfile
@@ -1,5 +1,7 @@
 FROM php:8-apache as partial
 
+# Use production PHP settings
+RUN mv /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 # Load extra Apache modules
 RUN a2enmod rewrite headers
 # Installs sendmail

--- a/docker-php/init.sh
+++ b/docker-php/init.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+groupadd --gid "$PUID" ezxss || true
+useradd --system --uid "$PUID" --gid "$PGID" ezxss || true
+chown ezxss: /var/www/html -R || true
+chown ezxss /var/log/apache2/error.log || true
+chown ezxss /var/log/apache2/other_vhosts_access.log || true
+echo "Launching application with UID $PUID and GID $PGID"
+runuser -u ezxss apache2-foreground


### PR DESCRIPTION
By default, processes in Docker containers run as root.
It is a good practice to run processes as non-elevated users.
This changeset allows the user to set a configurable UID/GID for the webserver to run as.

To configure the webserver to run with UID/GID 1000, change your `docker-compose.yml`:
```yaml
# ...
    environment:
      - PUID=1000
      - PGID=1000
# ...
```
Note that this is for the full docker image [42elyesa/ezxss](https://hub.docker.com/r/42elyesa/ezxss).

If you want to set the UID/GID for the partial docker image you can use the `user` directive, e.g.:
```yaml
# ...
    user: 1000:1000
# ...
```

Other changes included:
- Make sure that default production PHP settings are applied (disable printing error messages to browser, etc.)