### PR TITLE
Proper docker-compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 .github/
 .gitignore
-.env
 Dockerfile
 docker-compose.yml
 readme.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.github/
+.gitignore
+.env
+Dockerfile
+docker-compose.yml
+msmtprc
+readme.md
+nginx-rewrite.conf

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,5 @@
 .env
 Dockerfile
 docker-compose.yml
-msmtprc
 readme.md
 nginx-rewrite.conf

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 .github/
 .gitignore
+.git/
 Dockerfile
 docker-compose.yml
 readme.md

--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,5 @@ dbUser=ezxss
 dbPassword=changeme
 dbName=database
 dbPort=3306
+PORT=80
+TLSPORT=443

--- a/.env.example
+++ b/.env.example
@@ -3,5 +3,6 @@ dbUser=ezxss
 dbPassword=changeme
 dbName=database
 dbPort=3306
+dbDir="/opt/ezxss"
 PORT=80
 TLSPORT=443

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,7 @@ RUN chown www-data:www-data /etc/msmtprc
 RUN chown www-data:www-data /var/log/msmtp.log
 RUN echo "sendmail_path = /usr/bin/msmtp -t" >> /usr/local/etc/php/conf.d/php-sendmail.ini
 
-COPY init.sh /usr/local/bin/
-RUN chmod +x /usr/local/bin/init.sh
-
 COPY . /var/www/html
 
-ENV PUID=2000
-ENV PGID=2000
-CMD ["/usr/local/bin/init.sh"]
+ENTRYPOINT ["docker-php-entrypoint"]
+CMD ["apache2-foreground"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@ FROM php:8-apache
 
 RUN mv /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 
-RUN a2enmod rewrite headers
+RUN echo "RemoteIPHeader X-Forwarded-For" >> /etc/apache2/conf-enabled/remoteip.conf
+RUN echo "RemoteIPInternalProxy 172.16.0.0/12" >> /etc/apache2/conf-enabled/remoteip.conf
+RUN a2enmod rewrite headers remoteip
 
 RUN apt-get update && apt-get install -y msmtp && rm -rf /var/lib/apt/lists/*
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.7'
 
 services:
   ezxssdb:
@@ -11,16 +11,14 @@ services:
       - MYSQL_USER=${dbUser}
       - MYSQL_PASSWORD=${dbPassword}
     volumes:
-      - ./ezxssdb:/var/lib/mysql
+      - ${dbDir}:/var/lib/mysql
   ezxss:
     build:
       context: .
       dockerfile: ./Dockerfile
     ports:
-      - "80:80"
-      - "443:443"
-    volumes:
-      - .:/var/www/html
+      - "${PORT:-80}:80"
+      - "${TLSPORT:-443}:443"
     restart: always
     depends_on:
       - ezxssdb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - MYSQL_USER=${dbUser}
       - MYSQL_PASSWORD=${dbPassword}
     volumes:
-      - ${dbDir}:/var/lib/mysql
+      - "${dbDir}:/var/lib/mysql"
   ezxss:
     build:
       context: .


### PR DESCRIPTION
This pull request will clean up the compose file and only copy the needed files to the image, it will lower the size, and the attack surface.

It allows users to host the ezXSS server on any port, to allow forward proxies (I will update documentation in wiki as needed if this PR gets accepted)
It also allows users to store the mysql database in any location.

Should work with root and non-root docker users.