### PR TITLE
Fixing "Conversion from collation utf8mb3_general_ci into utf8mb4_0900_ai_ci impossible" error

### DIFF
--- a/system/Database.php
+++ b/system/Database.php
@@ -30,7 +30,7 @@ class Database
     {
         if ($this->connection === null) {
             // Construct a new connection
-            $this->connection = new PDO('mysql:dbname=' . DB_NAME . ';host=' . DB_HOST . ';port=' . DB_PORT . ';charset=utf8', DB_USER, DB_PASS);
+            $this->connection = new PDO('mysql:dbname=' . DB_NAME . ';host=' . DB_HOST . ';port=' . DB_PORT . ';charset=utf8mb4', DB_USER, DB_PASS);
 
             $this->connection->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
             $this->connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);


### PR DESCRIPTION
 Fix for "Conversion from collation utf8mb3_general_ci into utf8mb4_0900_ai_ci impossible"

I ran into some trouble with emojis, it seems to be fixed since for https://github.com/ssl/ezXSS/issues/95 but i still get it on some websites such as [https://emojidictionary.emojifoundation.com/locked_with_key](https://emojidictionary.emojifoundation.com/locked_with_key). 
It seems to be coming from the database charset while initiating connection. The bug can be reproduced using the [https://ez.pe/](https://ez.pe/) instance.

![error](https://user-images.githubusercontent.com/9656826/228536316-c8b23de4-236f-4d02-b0c4-0ff94af534c6.png)

I have issued a quick patch, just changing the charset to utf8mb4.


