### PR TITLE
Release 4.1 docker fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,6 @@ dbName=database
 dbPort=3306
 
 # Docker settings
-dbDir="/opt/ezxss"
 dockerHttpPort=80
 dockerHttpsPort=443
 

--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,8 @@ dbPort=3306
 
 # Docker settings
 dbDir="/opt/ezxss"
-PORT=80
-TLSPORT=443
+dockerHttpPort=80
+dockerHttpsPort=443
 
 # ezProxy settings
 prHost=0.0.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,6 @@ RUN chmod 640 /etc/msmtprc
 RUN touch /var/log/msmtp.log
 RUN chown root:msmtp /etc/msmtprc
 RUN chown root:msmtp /var/log/msmtp.log
-RUN chown root:msmtp /etc/msmtprc
-RUN chown root:msmtp /var/log/msmtp.log
 RUN echo "sendmail_path = /usr/bin/msmtp -t" >> /usr/local/etc/php/conf.d/php-sendmail.ini
 
 COPY . /var/www/html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - MYSQL_USER=${dbUser}
       - MYSQL_PASSWORD=${dbPassword}
     volumes:
-      - "${dbDir}:/var/lib/mysql"
+      - "./ezxssdb:/var/lib/mysql"
   ezxss:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,8 @@ services:
       context: .
       dockerfile: ./Dockerfile
     ports:
-      - "${PORT:-80}:80"
-      - "${TLSPORT:-443}:443"
+      - "${dockerHttpPort:-80}:80"
+      - "${dockerHttpsPort:-443}:443"
     volumes:
       - .:/var/www/html
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
     ports:
       - "${PORT:-80}:80"
       - "${TLSPORT:-443}:443"
+    volumes:
+      - .:/var/www/html
     restart: always
     depends_on:
       - ezxssdb


### PR DESCRIPTION
PR #114 made unnecessary changes to the docker configuration which breaks existing installs and was partially incomplete.

This PR updates the default docker setup to not break existing installs and remove unneeded changes.

- Restores persistent volume for web files
- Removes redundant / repeated lines from `Dockerfile`
- Updates docker port environment variables to match existing camelCase
- Restores default database volume location to relative path. 
  - If a user wishes to run ezXSS in an arbitrary directory, they can simply place the repo in that directory and don't need to change environment variables. 
  - Additionally, there is no reason to move the database volume outside of the ezxss folder by default since the `.htaccess` rewrites prevent it from being accessed.
  - Restoring this to the way it was for the last couple years will to follow the KISS principle and keep the docker/ezxss files contained in one location. If a user is fully opposed to this approach, they can modify their own `docker-compose.yml` file the way is done with many other docker provided projects. 
