### PR TITLE
Bugfix MFA broken when password has special chars + password security fixes

### DIFF
--- a/app/controllers/Account.php
+++ b/app/controllers/Account.php
@@ -139,7 +139,7 @@ class Account extends Controller
                 $password = $this->session->data('password');
                 $code = $this->getPostValue('code');
 
-                $user = $this->model('User')->login($username, $password);
+                $user = $this->model('User')->login($username, $password, true);
 
                 if (getAuthCode($user['secret']) != $code) {
                     throw new Exception('Code is incorrect');

--- a/app/controllers/Account.php
+++ b/app/controllers/Account.php
@@ -99,7 +99,6 @@ class Account extends Controller
                 $user = $this->model('User')->login($username, $password);
 
                 if (strlen($user['secret']) === 16) {
-                    $user['password'] = $password;
                     $this->session->createTempSession($user);
                     redirect('/manage/account/mfa');
                 } else {
@@ -135,11 +134,9 @@ class Account extends Controller
             try {
                 $this->validateCsrfToken();
 
-                $username = $this->session->data('username');
-                $password = $this->session->data('password');
                 $code = $this->getPostValue('code');
 
-                $user = $this->model('User')->login($username, $password, true);
+                $user = $this->model('User')->getById($this->session->data('id'));
 
                 if (getAuthCode($user['secret']) != $code) {
                     throw new Exception('Code is incorrect');
@@ -234,7 +231,7 @@ class Account extends Controller
         }
 
         $this->log('Changed password');
-        $this->model('User')->setPassword($user['id'], $newPassword);
+        $this->model('User')->setPassword($user['id'], $newPassword, true);
     }
 
     /**

--- a/app/controllers/Account.php
+++ b/app/controllers/Account.php
@@ -231,7 +231,7 @@ class Account extends Controller
         }
 
         $this->log('Changed password');
-        $this->model('User')->setPassword($user['id'], $newPassword, true);
+        $this->model('User')->setPassword($user['id'], $newPassword);
     }
 
     /**

--- a/app/controllers/Users.php
+++ b/app/controllers/Users.php
@@ -103,7 +103,7 @@ class Users extends Controller
                         if ($user['id'] == $this->session->data('id')) {
                             throw new Exception("Can't edit your own users password here");
                         }
-                        $userModel->setPassword($user['id'], $password);
+                        $userModel->setPassword($user['id'], $password, true);
                     }
 
                     // Check if posted data wants to change username

--- a/app/controllers/Users.php
+++ b/app/controllers/Users.php
@@ -103,7 +103,7 @@ class Users extends Controller
                         if ($user['id'] == $this->session->data('id')) {
                             throw new Exception("Can't edit your own users password here");
                         }
-                        $userModel->setPassword($user['id'], $password, true);
+                        $userModel->setPassword($user['id'], $password);
                     }
 
                     // Check if posted data wants to change username

--- a/app/models/User.php
+++ b/app/models/User.php
@@ -17,7 +17,7 @@ class User_model extends Model
      * @throws Exception
      * @return bool
      */
-    public function login($username, $password)
+    public function login($username, $password, $mfa = false)
     {
 
         $database = Database::openConnection();
@@ -29,8 +29,14 @@ class User_model extends Model
 
         $user = $database->fetch();
 
-        if (!password_verify($password, $user['password'])) {
-            throw new Exception("Login combination not found");
+        if ($mfa) {
+            if(!hash_equals($password, $user['password'])) {
+                throw new Exception("Login combination not found");
+            }
+        } else {
+            if (!password_verify($password, $user['password'])) {
+                throw new Exception("Login combination not found");
+            }
         }
 
         if ($user['rank'] == 0) {

--- a/app/models/User.php
+++ b/app/models/User.php
@@ -15,9 +15,9 @@ class User_model extends Model
      * @param string $username The username
      * @param string $password The password
      * @throws Exception
-     * @return bool
+     * @return array
      */
-    public function login($username, $password, $mfa = false)
+    public function login($username, $password)
     {
 
         $database = Database::openConnection();
@@ -29,14 +29,8 @@ class User_model extends Model
 
         $user = $database->fetch();
 
-        if ($mfa) {
-            if(!hash_equals($password, $user['password'])) {
-                throw new Exception("Login combination not found");
-            }
-        } else {
-            if (!password_verify($password, $user['password'])) {
-                throw new Exception("Login combination not found");
-            }
+        if (!password_verify($password, $user['password'])) {
+            throw new Exception("Login combination not found");
         }
 
         if ($user['rank'] == 0) {

--- a/system/Controller.php
+++ b/system/Controller.php
@@ -123,7 +123,7 @@ class Controller
                 $account = $this->model('User')->getById($this->session->data('id'));
 
                 // Check if the password has been changed
-                if ($this->session->data('password_hash') != md5($account['password'])) {
+                if (!password_verify($account['password'], $this->session->data('password_hash'))) {
                     throw new Exception("Password has been changed");
                 }
 

--- a/system/Session.php
+++ b/system/Session.php
@@ -55,7 +55,7 @@ class Session
         $_SESSION['username'] = $user['username'];
         $_SESSION['id'] = $user['id'];
         $_SESSION['rank'] = intval($user['rank']);
-        $_SESSION['password_hash'] = md5($user['password']);
+        $_SESSION['password_hash'] = password_hash($user['password'], PASSWORD_BCRYPT, ['cost' => 14]);
         $_SESSION['ip'] = userip;
     }
 
@@ -81,8 +81,7 @@ class Session
     {
         $_SESSION['loggedIn'] = false;
         $_SESSION['temp'] = true;
-        $_SESSION['username'] = $user['username'];
-        $_SESSION['password'] = $user['password'];
+        $_SESSION['id'] = $user['id'];
     }
 
     /**


### PR DESCRIPTION
MFA was not working if the password had special chars (HTML entities is executed on data fetched from session).

- Just store user ID in temp session (bad practice to store plaintext pass, users can't tamper with server-side session, so user ID should be enough)
- Changed password hash in other session from md5 hashing to proper BCRYPT hashing