### PR TITLE
Optional mail alerts with docker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ dbPort=3306
 # Docker settings
 dockerHttpPort=80
 dockerHttpsPort=443
-USE_MAIL_ALERTS=true
+useMailAlerts=true
 
 # ezProxy settings
 prHost=0.0.0.0

--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@ dbPort=3306
 # Docker settings
 dockerHttpPort=80
 dockerHttpsPort=443
+USE_MAIL_ALERTS=true
 
 # ezProxy settings
 prHost=0.0.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile
+      args:
+        - USE_MAIL_ALERTS=${USE_MAIL_ALERTS}
     ports:
       - "${dockerHttpPort:-80}:80"
       - "${dockerHttpsPort:-443}:443"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       context: .
       dockerfile: ./Dockerfile
       args:
-        - USE_MAIL_ALERTS=${USE_MAIL_ALERTS}
+        - USE_MAIL_ALERTS=${useMailAlerts}
     ports:
       - "${dockerHttpPort:-80}:80"
       - "${dockerHttpsPort:-443}:443"


### PR DESCRIPTION
These changes let users option to create or not smtp infrastructure based on `msmtp` by new `USE_MAIL_ALERTS` environment variable.
For me it also helps to avoid #133 issue.