### PR TITLE
Fix after 4.3 db update

### DIFF
--- a/app/sql/4.3.sql
+++ b/app/sql/4.3.sql
@@ -115,7 +115,7 @@ INSERT INTO `settings` (`id`, `setting`, `value`) VALUES
 (4, 'timezone', 'Europe/Amsterdam'),
 (5, 'customjs', ''),
 (7, 'notepad', 'Welcome to ezXSS 4!'),
-(8, 'version', '4.2'),
+(8, 'version', '4.3'),
 (9, 'killswitch', ''),
 (10, 'collect_uri', '1'),
 (11, 'collect_ip', '1'),


### PR DESCRIPTION
I run into a problem when I made a fresh installation of ezXSS via docker. After clicking install, I kept on getting message to "update" and when you click on update it gives error:
SQLSTATE[42000]: Syntax error or access violation: 1101 BLOB, TEXT, GEOMETRY or JSON column 'customjs2' can't have a default value

It appears that just fresh installation creates db for 4.3 while having 4.2 in the db entry itself and 4.2-4.3 update fails, so here a little fix before someone else will bump into this problem 

Might need to change somewhere else as well since on app it still shows like it's a 4.2 version (or I guess on app it just fetches github info), but at least it works for now.