### PR TITLE
Update Trigger.php

### DIFF
--- a/app/controllers/Trigger.php
+++ b/app/controllers/Trigger.php
@@ -18,7 +18,7 @@ class Trigger extends Controller
 
         // CORS headers
         header('Access-Control-Allow-Origin: *');
-        header('Access-Control-Allow-Headers: origin, x-requested-with, content-type');
+        header('Access-Control-Allow-Headers: *');
         header('Access-Control-Allow-Methods: GET, POST');
 
         // Cache headers


### PR DESCRIPTION
The previous values set for Access-Control-Allow-Headers: led to many javascript requests failing due to CORS errors when the request contains unexpected headers such as csrf headers, etc. 

![Screenshot 2025-06-11 144300](https://github.com/user-attachments/assets/07bb39f7-31b9-409e-8a2d-b7e11f551871)
